### PR TITLE
add reference contrast to calculation of ppFact

### DIFF
--- a/ebs/error_budget.py
+++ b/ebs/error_budget.py
@@ -141,6 +141,7 @@ class ErrorBudget(ExosimsWrapper):
         self.input_dir = self.config["paths"]["input"]
         self.temp_dir = self.config["paths"]["temporary"]
 
+        self.ref_contrast = self.config["reference_contrast"]
         self.wfe = None
         self.wfsc_factor = None
         self.sensitivity = None
@@ -197,7 +198,7 @@ class ErrorBudget(ExosimsWrapper):
         - See <Post-Processing Factor> document for mathematical description
 
         """
-        ppFact = self.delta_contrast/self.contrast
+        ppFact = self.delta_contrast/np.sqrt(self.contrast * self.ref_contrast)
         return np.where(ppFact>1.0, 1.0, ppFact)
 
     def load_csv_contrast(self):

--- a/inputs/parameters.yml
+++ b/inputs/parameters.yml
@@ -10,6 +10,7 @@ input_files:
   wfsc: baseline_wfsc.csv
   sensitivity: baseline_sensitivity.csv
 
+reference_contrast: 1.0e-10
 #json_file: example_ref.json  # An input specifying the 'unaberrated' observatory
 
 # Basic EXOSIMS Parameters

--- a/inputs/parameters.yml
+++ b/inputs/parameters.yml
@@ -7,7 +7,7 @@ input_files:
   contrast: baseline_contrast.csv
   throughput: baseline_throughput.csv
   wfe: baseline_wfe.csv
-  wfsc: baseline_wfsc.csv
+  wfsc_factor: baseline_wfsc.csv
   sensitivity: baseline_sensitivity.csv
 
 reference_contrast: 1.0e-10

--- a/test/inputs/test_parameters.yml
+++ b/test/inputs/test_parameters.yml
@@ -7,8 +7,10 @@ input_files:
   contrast: test_contrast.csv
   throughput: test_throughput.csv
   wfe: test_wfe.csv
-  wfsc: test_wfsc.csv
+  wfsc_factor: test_wfsc.csv
   sensitivity: test_sensitivity.csv
+
+reference_contrast:  1.0e-10
 
 # Basic EXOSIMS Parameters
 initial_exosims:

--- a/test/inputs/test_parameters_mcmc.yml
+++ b/test/inputs/test_parameters_mcmc.yml
@@ -7,8 +7,10 @@ input_files:
   contrast: mcmc_contrast.csv
   throughput: mcmc_throughput.csv
   wfe: mcmc_wfe.csv
-  wfsc: mcmc_wfsc.csv
+  wfsc_factor: mcmc_wfsc.csv
   sensitivity: mcmc_sensitivity.csv
+
+reference_contrast: 1.0e-10
 
 # Basic EXOSIMS Parameters
 initial_exosims:

--- a/test/test_ebs.py
+++ b/test/test_ebs.py
@@ -140,7 +140,8 @@ def test_mcmc_ppFact(obs_mcmc):
                 assert obs_mcmc.ppFact[i] == 1.0
             else:
                 assert (0.0 <= obs_mcmc.ppFact[i] ==
-                        obs_mcmc.delta_contrast[i]/contrast)
+                        obs_mcmc.delta_contrast[i]/np.sqrt(obs_mcmc.contrast[i]
+                                                       *obs_mcmc.ref_contrast))
         obs_mcmc.clean_files()
 
 


### PR DESCRIPTION
Since sensitivities are calculated around a given reference contrast, this PR adds in that normalization into the calculation of ppFact. Also adds the reference contrast as a user-defined parameter in the parameters.yml file.  

Before merge needs confirmation and review from Pin and Laurent. 